### PR TITLE
Make python 2/3 compatible

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+
+branch = True
+omit =
+    .tox/*
+    setup.py
+
+[paths]
+
+source =
+    tests
+    flask_htpasswd
+
+[report] 
+exclude_lines =
+    pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ language: python
 python:
   - 2.7
 install:
-  - pip install -e .
-  - pip install -r test_requirements.txt
   - pip install coveralls
 script:
-  - nosetests --with-coverage --cover-package=flask_htpasswd --cover-branches
-  - pep8 *.py
-  - pylint *.py
+  - python setup.py install
+  - python setup.py test
 after_success:
   coveralls

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 include README.rst
 include LICENSE
 include test_requirements.txt
+include tox.ini
+include pytest.ini
+include .coveragerc

--- a/flask_htpasswd.py
+++ b/flask_htpasswd.py
@@ -3,6 +3,7 @@
 Decorator, configuration, and error handler for basic and token
 authentication using htpasswd files
 """
+from __future__ import absolute_import, unicode_literals
 from functools import wraps
 import hashlib
 import logging
@@ -101,7 +102,7 @@ class HtPasswdAuth(object):
                 'username': username,
                 'hashhash': self.get_hashhash(username)
             }
-        )
+        ).decode('UTF-8')
 
     def check_token_auth(self, token):
         """

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov . --cov-config .coveragerc --pep8 --pylint --cov-report term --cov-report html

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,45 @@ Links
 * `development version
   <https://github.com/carsongee/flask-htpasswd/archive/master.tar.gz#egg=flask-htpasswd-dev>`_
 """
-
+from __future__ import absolute_import, unicode_literals
+import codecs
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
 
-with open('README.rst') as readme:
+with codecs.open('README.rst', encoding='utf-8') as readme:
     README = readme.read()
 
-with open('test_requirements.txt') as test_reqs:
-    TESTS_REQUIRE = test_reqs.readlines(),
+
+class Tox(TestCommand):
+    """
+    Boiler plate test command for running tox with ``python setup.py test``.
+    Borrowed from: https://testrun.org/tox/latest/example/basic.html
+    """
+    # pylint: disable=attribute-defined-outside-init
+    user_options = [(
+        str('tox-args='),
+        str('a'),
+        str('Arguments to pass to tox')
+    )]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.tox_args = []
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # Import here, cause outside the eggs aren't loaded
+        import tox  # pylint: disable=import-error
+        import shlex
+        args = self.tox_args
+        if args:
+            args = shlex.split(self.tox_args)
+        tox.cmdline(args=args)
+
 
 setup(
     name='flask-htpasswd',
@@ -40,9 +71,10 @@ setup(
         'Flask',
         'passlib',
         'itsdangerous',
+        'tox',
     ],
-    tests_require=TESTS_REQUIRE,
-    test_suite="nose.collector",
+    tests_require=['tox'],
+    cmdclass={'test': Tox},
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -50,6 +82,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,8 @@
-coverage
 mock
-nose
-pep8
-pylint
+pytest
+pytest-pep8
+pytest-pylint
+pytest-cov
+pytest-capturelog
+pytest-watch
+coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py{27,33,34}
+skip_missing_interpreters = True
+
+[testenv]
+
+deps =
+    -r{toxinidir}/test_requirements.txt
+
+commands =
+    py.test {posargs}


### PR DESCRIPTION
This should make flask-htpasswd python 3 compatible, and includes changes to the test infrastructure to vet that (tox and pytest).
