### PR TITLE
Switch from itsdangerous to pyjwt + FLASK_SECRET fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
+  - 3.10
 install:
   - pip install coveralls tox-travis
 script:

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,11 @@ It can then be used by the user by adding it to the header of their requests, so
 Release Notes
 =============
 
-0.3.1
+0.4.0
+`````
+
+- Updated for newer language and Flask versions
+
 `````
 
 - Corrected deprecated passlib API call
@@ -122,7 +126,7 @@ Release Notes
 0.2.0
 `````
 
-- Python 3 compatability
+- Python 3 compatibility
 
 Acknowledgements
 ================

--- a/README.rst
+++ b/README.rst
@@ -108,13 +108,16 @@ It can then be used by the user by adding it to the header of their requests, so
 Release Notes
 =============
 
+0.5.0
+`````
+
+- Switch from itsdangerous to pyjwt
+- Renamed FLASK_SECRET into SECRET_KEY
+
 0.4.0
 `````
 
 - Updated for newer language and Flask versions
-
-`````
-
 - Corrected deprecated passlib API call
 
 0.3.0

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ something like:
 
   app = flask.Flask(__name__)
   app.config['FLASK_HTPASSWD_PATH'] = '/path/to/.htpasswd'
-  app.config['FLASK_SECRET'] = 'Hey Hey Kids, secure me!'
+  app.config['SECRET_KEY'] = 'Hey Hey Kids, secure me!'
 
   htpasswd = HtPasswdAuth(app)
   
@@ -85,7 +85,7 @@ can serve it out to the user with something like
 
   app = flask.Flask(__name__)
   app.config['FLASK_HTPASSWD_PATH'] = '/path/to/.htpasswd'
-  app.config['FLASK_SECRET'] = 'Hey Hey Kids, secure me!'
+  app.config['SECRET_KEY'] = 'Hey Hey Kids, secure me!'
   htpasswd = HtPasswdAuth(app)
   
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ something like:
 
   app = flask.Flask(__name__)
   app.config['FLASK_HTPASSWD_PATH'] = '/path/to/.htpasswd'
-  app.config['SECRET_KEY'] = 'Hey Hey Kids, secure me!'
+  app.config['FLASK_SECRET'] = 'Hey Hey Kids, secure me!'
 
   htpasswd = HtPasswdAuth(app)
   
@@ -85,7 +85,7 @@ can serve it out to the user with something like
 
   app = flask.Flask(__name__)
   app.config['FLASK_HTPASSWD_PATH'] = '/path/to/.htpasswd'
-  app.config['SECRET_KEY'] = 'Hey Hey Kids, secure me!'
+  app.config['FLASK_SECRET'] = 'Hey Hey Kids, secure me!'
   htpasswd = HtPasswdAuth(app)
   
 
@@ -112,7 +112,7 @@ Release Notes
 `````
 
 - Switch from itsdangerous to pyjwt
-- Renamed FLASK_SECRET into SECRET_KEY
+- Renamed FLASK_SECRET into FLASK_SECRET
 
 0.4.0
 `````

--- a/README.rst
+++ b/README.rst
@@ -133,9 +133,9 @@ Acknowledgements
 
 This is largely based on a combination of:
 
-- http://flask-basicauth.readthedocs.org/en/latest/
-- http://flask.pocoo.org/snippets/8/
-- http://blog.miguelgrinberg.com/post/restful-authentication-with-flask
+- https://flask-basicauth.readthedocs.io/en/latest/
+- `https://flask.pocoo.org/snippets/8/ <https://web.archive.org/web/20190706125230/https://flask.pocoo.org/snippets/8/>`_
+- https://blog.miguelgrinberg.com/post/restful-authentication-with-flask
 
 
 Links

--- a/flask_htpasswd.py
+++ b/flask_htpasswd.py
@@ -95,7 +95,7 @@ class HtPasswdAuth:
         Setup crypto sig.
         """
         with self.app.app_context():
-            return current_app.config['SECRET_KEY']
+            return current_app.config['FLASK_SECRET']
 
     def get_hashhash(self, username):
         """

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,8 @@ setup(
     python_requires=">=3.5",
     install_requires=[
         'Flask',
-        'passlib>=1.6',
-        'itsdangerous',
+        'passlib',
+        'pyjwt',
         'tox',
     ],
     tests_require=['tox'],

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class Tox(TestCommand):
 
 setup(
     name='flask-htpasswd',
-    version='0.4.0',
+    version='0.5.0',
     url='http://github.com/carsongee/flask-htpasswd',
     license='BSD New',
     author='Carson Gee',

--- a/tests/test_htpasswd.py
+++ b/tests/test_htpasswd.py
@@ -25,7 +25,7 @@ class TestAuth(unittest.TestCase):
     def setUp(self):
         super(TestAuth, self).setUp()
         self.app = Flask(__name__)
-        self.app.config['FLASK_SECRET'] = 'dummy'
+        self.app.config['SECRET_KEY'] = 'dummy'
         self.app.debug = True
         self.htpasswd = None
 
@@ -118,7 +118,7 @@ class TestAuth(unittest.TestCase):
             # Now that we verified our hashhash, independently verify
             # the data with a serializer from config (not trusting
             # get_signature here).
-            key = self.app.config['FLASK_SECRET']
+            key = self.app.config['SECRET_KEY']
             decoded_hashhash = jwt.decode(token, key, algorithms=["HS512"])['hashhash']
             self.assertEqual(hashhash, decoded_hashhash)
 

--- a/tests/test_htpasswd.py
+++ b/tests/test_htpasswd.py
@@ -25,7 +25,7 @@ class TestAuth(unittest.TestCase):
     def setUp(self):
         super(TestAuth, self).setUp()
         self.app = Flask(__name__)
-        self.app.config['SECRET_KEY'] = 'dummy'
+        self.app.config['FLASK_SECRET'] = 'dummy'
         self.app.debug = True
         self.htpasswd = None
 
@@ -118,7 +118,7 @@ class TestAuth(unittest.TestCase):
             # Now that we verified our hashhash, independently verify
             # the data with a serializer from config (not trusting
             # get_signature here).
-            key = self.app.config['SECRET_KEY']
+            key = self.app.config['FLASK_SECRET']
             decoded_hashhash = jwt.decode(token, key, algorithms=["HS512"])['hashhash']
             self.assertEqual(hashhash, decoded_hashhash)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38}
+envlist = py{35,36,37,38,39,310}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Hello,

I'm opening this pull request to submit a new library for generating Json Web Tokens.

As itsdangerous doesn't have JSONWebSignatureSerializer features anymore (https://itsdangerous.palletsprojects.com/en/2.0.x/jws/) I switched to pyjwt.
PyJWT is more specific to this usage and has an active repo as well

I did some testing and everything looks good so far, did some bug fixes as well and changed FLASK_SECRET to SECRET_KEY (I don't know what FLASK_SECRET was refering to, maybe an old flask version)

I also revert your latest commit because of a typo (you can revert it as well before merging this PR if you want to keep it clean)

I'd be happy to see it live because users are constrained using `itsdangerous==2.0.1` with the module

Feel free to ask any change you need